### PR TITLE
8.B Sigma Rule - Py2Exe

### DIFF
--- a/rules/windows/sysmon/susp_python_image_load.yaml
+++ b/rules/windows/sysmon/susp_python_image_load.yaml
@@ -1,0 +1,25 @@
+title: Python Py2Exe Image Load
+description: Detects the image load of Python Core indicative of a Python script bundled with Py2Exe.
+references:
+- https://www.py2exe.org/
+- https://unit42.paloaltonetworks.com/unit-42-technical-analysis-seaduke/
+author: Patrick St. John
+status: experimental
+date: 2020/05/03
+logsource:
+  product: windows
+  service: sysmon
+detection:
+  selection:
+    EventID: 7
+    Description: 'Python Core'
+  condition: selection
+fields:
+- Description
+falsepositives:
+- Legit Py2Exe Binaries
+level: medium
+tags:
+- attack.defense_evasion
+- attack.t1045
+- attack.s0053


### PR DESCRIPTION
Generic py2exe or similar detection. Looking for Python Core being loaded. Might not be abnormal in all environments if admins bundle scripts using this technique.